### PR TITLE
Added file header to make cl-strings work with quicklisp in LispWorks

### DIFF
--- a/cl-strings.lisp
+++ b/cl-strings.lisp
@@ -1,3 +1,5 @@
+;;; -*- mode: lisp; encoding: (utf-8) -*-
+
 (in-package :cl-strings)
 
 (defvar *blank-chars* '(#\Space #\Newline #\Backspace #\Tab


### PR DESCRIPTION
This fixes https://github.com/diogoalexandrefranco/cl-strings/issues/10